### PR TITLE
refactor: throw custom error for empty files

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/graasp/graasp-plugin-file#readme",
   "dependencies": {
     "@fastify/multipart": "6.0.0",
-    "@graasp/translations": "github:graasp/graasp-translations#13/emptyUpload",
+    "@graasp/translations": "github:graasp/graasp-translations",
     "aws-sdk": "2.1111.0",
     "content-disposition": "0.5.4",
     "fs-extra": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/graasp/graasp-plugin-file#readme",
   "dependencies": {
     "@fastify/multipart": "6.0.0",
-    "@graasp/translations": "github:graasp/graasp-translations",
+    "@graasp/translations": "github:graasp/graasp-translations#13/emptyUpload",
     "aws-sdk": "2.1111.0",
     "content-disposition": "0.5.4",
     "fs-extra": "10.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { default } from './plugin';
 export * from './types';
 export { default as FileTaskManager } from './task-manager';
+export * from './utils/errors';

--- a/src/tasks/upload-file-task.test.ts
+++ b/src/tasks/upload-file-task.test.ts
@@ -9,12 +9,11 @@ import {
   buildDefaultLocalOptions,
   FILE_SERVICES,
   DEFAULT_S3_OPTIONS,
-  IMAGE_PATH,
   TEXT_FILE_PATH,
 } from '../../test/fixtures';
 import { LocalService } from '../fileServices/localService';
 import { S3Service } from '../fileServices/s3Service';
-import { UploadFileInvalidParameterError } from '../utils/errors';
+import { UploadEmptyFileError, UploadFileInvalidParameterError } from '../utils/errors';
 import UploadFileTask from './upload-file-task';
 
 const handler = {} as unknown as DatabaseTransactionHandler;
@@ -91,7 +90,7 @@ describe('Upload File Task', () => {
 
     const task = new UploadFileTask(actor, buildFileService(service), input);
     expect(async () => await task.run(handler, log)).rejects.toEqual(
-      new UploadFileInvalidParameterError({
+      new UploadEmptyFileError({
         file: DEFAULT_FILE_STREAM,
         filepath: input.filepath,
         size: input.size,

--- a/src/tasks/upload-file-task.ts
+++ b/src/tasks/upload-file-task.ts
@@ -3,7 +3,7 @@ import type { FastifyLoggerInstance } from 'fastify';
 import { ReadStream } from 'fs';
 import { BaseTask } from './base-task';
 import FileService from '../fileServices/interface/fileService';
-import { UploadFileInvalidParameterError } from '../utils/errors';
+import { UploadEmptyFileError, UploadFileInvalidParameterError } from '../utils/errors';
 
 export type UploadFileInputType = {
   file?: ReadStream;
@@ -37,8 +37,16 @@ class UploadFileTask extends BaseTask<Actor, Item> {
 
     const { file, mimetype, filepath, size } = this.input;
 
-    if (!file || !filepath || !size) {
+    if (!file || !filepath) {
       throw new UploadFileInvalidParameterError({
+        file,
+        filepath,
+        size,
+      });
+    }
+
+    if (!size) {
+      throw new UploadEmptyFileError({
         file,
         filepath,
         size,

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -109,3 +109,16 @@ export class S3FileNotFound extends GraaspBaseError {
     );
   }
 }
+
+export class UploadEmptyFileError extends GraaspBaseError {
+  constructor(data?: unknown) {
+    super(
+      {
+        code: 'GPFERR008',
+        statusCode: StatusCodes.BAD_REQUEST,
+        message: FAILURE_MESSAGES.UPLOAD_EMPTY_FILE,
+      },
+      data,
+    );
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -678,12 +678,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/translations@github:graasp/graasp-translations":
+"@graasp/translations@github:graasp/graasp-translations#13/emptyUpload":
   version: 0.1.0
-  resolution: "@graasp/translations@https://github.com/graasp/graasp-translations.git#commit=eee1d431f928cd5c2b38ef51103e98d8718b7357"
+  resolution: "@graasp/translations@https://github.com/graasp/graasp-translations.git#commit=3006148ee6df949a4653b831b07148ec6008494f"
   dependencies:
     i18next: 21.6.11
-  checksum: cf1cf527bda35d9c78241f21c910e5aa45028c1fdf79f6fe8e7a3388c28b66638a68c6228c4a094ff65c4da491456056e73df2a21a3d366be5fab865ed548e9e
+  checksum: d7a0799cbfae90895ecc240b2d574c7ac713f3f7e56b5da84a20e249da8637f385ebd3b539e2b5ea79243a703752b5ef2da872a65e70b433357caa72cc49906f
   languageName: node
   linkType: hard
 
@@ -3061,7 +3061,7 @@ __metadata:
     "@commitlint/cli": 16.2.3
     "@commitlint/config-conventional": 16.2.1
     "@fastify/multipart": 6.0.0
-    "@graasp/translations": "github:graasp/graasp-translations"
+    "@graasp/translations": "github:graasp/graasp-translations#13/emptyUpload"
     "@types/content-disposition": 0.5.4
     "@types/fs-extra": 9.0.13
     "@types/graasp": "github:graasp/graasp-types"

--- a/yarn.lock
+++ b/yarn.lock
@@ -678,9 +678,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/translations@github:graasp/graasp-translations#13/emptyUpload":
+"@graasp/translations@github:graasp/graasp-translations":
   version: 0.1.0
-  resolution: "@graasp/translations@https://github.com/graasp/graasp-translations.git#commit=3006148ee6df949a4653b831b07148ec6008494f"
+  resolution: "@graasp/translations@https://github.com/graasp/graasp-translations.git#commit=c84c5bbb3d8e952570641d97e67c91af2e3b9a7b"
   dependencies:
     i18next: 21.6.11
   checksum: d7a0799cbfae90895ecc240b2d574c7ac713f3f7e56b5da84a20e249da8637f385ebd3b539e2b5ea79243a703752b5ef2da872a65e70b433357caa72cc49906f
@@ -3061,7 +3061,7 @@ __metadata:
     "@commitlint/cli": 16.2.3
     "@commitlint/config-conventional": 16.2.1
     "@fastify/multipart": 6.0.0
-    "@graasp/translations": "github:graasp/graasp-translations#13/emptyUpload"
+    "@graasp/translations": "github:graasp/graasp-translations"
     "@types/content-disposition": 0.5.4
     "@types/fs-extra": 9.0.13
     "@types/graasp": "github:graasp/graasp-types"


### PR DESCRIPTION
We throw a custom error for empty files specifically to prettily fallback in zip import (we ignore empty files: empty text files).

close #24 