### PR TITLE
fix: copy metadata in copy folder task, style: apply imports prettier plugin

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,12 @@
   "trailingComma": "all",
   "tabWidth": 2,
   "semi": true,
-  "singleQuote": true
+  "singleQuote": true,
+  "importOrder": [
+    "^@?fastify*",
+    "^@?graasp*",
+    "^[./]"
+  ],
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@commitlint/cli": "16.2.3",
     "@commitlint/config-conventional": "16.2.1",
+    "@trivago/prettier-plugin-sort-imports": "3.2.0",
     "@types/content-disposition": "0.5.4",
     "@types/fs-extra": "9.0.13",
     "@types/graasp": "github:graasp/graasp-types",

--- a/src/fileServices/interface/fileService.ts
+++ b/src/fileServices/interface/fileService.ts
@@ -1,5 +1,6 @@
-import { FastifyReply } from 'fastify';
 import { ReadStream } from 'fs';
+
+import { FastifyReply } from 'fastify';
 
 export default interface FileService {
   copyFile(args: {

--- a/src/fileServices/localService.ts
+++ b/src/fileServices/localService.ts
@@ -1,13 +1,13 @@
 import contentDisposition from 'content-disposition';
 import fs from 'fs';
 import fse from 'fs-extra';
-import path from 'path';
 import { access, copyFile, mkdir, rm } from 'fs/promises';
+import path from 'path';
 import { pipeline } from 'stream/promises';
 
 import { GraaspLocalFileItemOptions } from '../types';
-import FileService from './interface/fileService';
 import { LocalFileNotFound } from '../utils/errors';
+import FileService from './interface/fileService';
 
 export class LocalService implements FileService {
   private readonly options: GraaspLocalFileItemOptions;

--- a/src/fileServices/s3Service.ts
+++ b/src/fileServices/s3Service.ts
@@ -1,14 +1,14 @@
 import S3 from 'aws-sdk/clients/s3';
 import contentDisposition from 'content-disposition';
 import fs from 'fs';
+import { StatusCodes } from 'http-status-codes';
 import fetch from 'node-fetch';
 import path from 'path';
 
 import { GraaspS3FileItemOptions } from '../types';
-import FileService from './interface/fileService';
-import { S3FileNotFound } from '../utils/errors';
-import { StatusCodes } from 'http-status-codes';
 import { S3_PRESIGNED_EXPIRATION } from '../utils/constants';
+import { S3FileNotFound } from '../utils/errors';
+import FileService from './interface/fileService';
 
 export class S3Service implements FileService {
   private readonly options: GraaspS3FileItemOptions;
@@ -83,7 +83,7 @@ export class S3Service implements FileService {
           CopySource: `${bucket}/${filepath}`,
           Bucket: bucket,
           Key: filepath.replace(originalFolderPath, newFolderPath),
-          MetadataDirective: 'REPLACE',
+          MetadataDirective: 'COPY',
           CacheControl: 'no-cache', // TODO: improve?
         };
         return this.s3Instance.copyObject(params).promise();

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,23 +1,25 @@
-import { FastifyPluginAsync } from 'fastify';
-import { Actor, IdParam, Member, Task } from 'graasp';
-import fastifyMultipart from '@fastify/multipart';
 import fs from 'fs';
 
+import fastifyMultipart from '@fastify/multipart';
+import { FastifyPluginAsync } from 'fastify';
+
+import { Actor, IdParam, Member, Task } from 'graasp';
+
+import { download, upload } from './schema';
 import FileTaskManager from './task-manager';
 import { AuthTokenSubject, ServiceMethod } from './types';
-import { download, upload } from './schema';
 import {
   BuildFilePathFunction,
-  DownloadPreHookTasksFunction,
   DownloadPostHookTasksFunction,
-  UploadPreHookTasksFunction,
-  UploadPostHookTasksFunction,
+  DownloadPreHookTasksFunction,
   GraaspLocalFileItemOptions,
   GraaspS3FileItemOptions,
+  UploadPostHookTasksFunction,
+  UploadPreHookTasksFunction,
 } from './types';
 import {
-  MAX_NUMBER_OF_FILES_UPLOAD,
   MAX_NB_TASKS_IN_PARALLEL,
+  MAX_NUMBER_OF_FILES_UPLOAD,
 } from './utils/constants';
 import { spliceIntoChunks } from './utils/utils';
 

--- a/src/task-manager.ts
+++ b/src/task-manager.ts
@@ -1,18 +1,19 @@
-import { Task, Actor } from 'graasp';
+import { Actor, Task } from 'graasp';
+
+import { LocalService } from './fileServices/localService';
+import { S3Service } from './fileServices/s3Service';
 import CopyFileTask, { CopyInputType } from './tasks/copy-file-task';
+import CopyFolderTask, { CopyFolderType } from './tasks/copy-folder-task';
 import DeleteFileTask, { DeleteFileInputType } from './tasks/delete-file-task';
-import DownloadFileTask, {
-  DownloadFileInputType,
-} from './tasks/download-file-task';
 import DeleteFolderTask, {
   DeleteFolderInputType,
 } from './tasks/delete-folder-task';
+import DownloadFileTask, {
+  DownloadFileInputType,
+} from './tasks/download-file-task';
 import UploadFileTask, { UploadFileInputType } from './tasks/upload-file-task';
 import { ServiceMethod } from './types';
-import { LocalService } from './fileServices/localService';
-import { S3Service } from './fileServices/s3Service';
 import { GraaspLocalFileItemOptions, GraaspS3FileItemOptions } from './types';
-import CopyFolderTask, { CopyFolderType } from './tasks/copy-folder-task';
 
 class TaskManager {
   private readonly fileService: LocalService | S3Service;

--- a/src/tasks/base-task.ts
+++ b/src/tasks/base-task.ts
@@ -1,13 +1,15 @@
 import { FastifyLoggerInstance } from 'fastify';
+
 import {
-  Task,
-  TaskStatus,
   Actor,
   DatabaseTransactionHandler,
-  PreHookHandlerType,
-  PostHookHandlerType,
   IndividualResultType,
+  PostHookHandlerType,
+  PreHookHandlerType,
+  Task,
+  TaskStatus,
 } from 'graasp';
+
 import FileService from '../fileServices/interface/fileService';
 
 export abstract class BaseTask<A extends Actor, R> implements Task<Actor, R> {

--- a/src/tasks/copy-file-task.test.ts
+++ b/src/tasks/copy-file-task.test.ts
@@ -1,21 +1,24 @@
-import { FastifyLoggerInstance } from 'fastify';
-import fs from 'fs';
-import { v4 } from 'uuid';
 import S3 from 'aws-sdk/clients/s3';
+import fs from 'fs';
+import path from 'path/posix';
+import { v4 } from 'uuid';
+
+import { FastifyLoggerInstance } from 'fastify';
+
 import { DatabaseTransactionHandler } from 'graasp';
+
 import { ServiceMethod } from '..';
 import {
-  GRAASP_ACTOR,
-  buildDefaultLocalOptions,
-  FILE_SERVICES,
   DEFAULT_S3_OPTIONS,
+  FILE_SERVICES,
+  GRAASP_ACTOR,
   TEXT_FILE_PATH,
+  buildDefaultLocalOptions,
 } from '../../test/fixtures';
 import { LocalService } from '../fileServices/localService';
 import { S3Service } from '../fileServices/s3Service';
 import { CopyFileInvalidPathError } from '../utils/errors';
 import CopyFileTask from './copy-file-task';
-import path from 'path/posix';
 
 const handler = {} as unknown as DatabaseTransactionHandler;
 const log = {} as unknown as FastifyLoggerInstance;

--- a/src/tasks/copy-file-task.ts
+++ b/src/tasks/copy-file-task.ts
@@ -1,8 +1,10 @@
-import { Actor, DatabaseTransactionHandler } from 'graasp';
 import type { FastifyLoggerInstance } from 'fastify';
-import { BaseTask } from './base-task';
+
+import { Actor, DatabaseTransactionHandler } from 'graasp';
+
 import FileService from '../fileServices/interface/fileService';
 import { CopyFileInvalidPathError } from '../utils/errors';
+import { BaseTask } from './base-task';
 
 export type CopyInputType = {
   newId?: string;

--- a/src/tasks/copy-folder-task.test.ts
+++ b/src/tasks/copy-folder-task.test.ts
@@ -1,13 +1,15 @@
 import { S3 } from 'aws-sdk';
-import { FastifyLoggerInstance } from 'fastify';
 import { existsSync } from 'fs';
 import { rm } from 'fs-extra';
 import { mkdir, readFile, writeFile } from 'fs/promises';
 import path from 'path';
+
+import { FastifyLoggerInstance } from 'fastify';
+
 import {
-  buildDefaultLocalOptions,
   DEFAULT_S3_OPTIONS,
   GRAASP_ACTOR,
+  buildDefaultLocalOptions,
 } from '../../test/fixtures';
 import { LocalService } from '../fileServices/localService';
 import { S3Service } from '../fileServices/s3Service';

--- a/src/tasks/copy-folder-task.ts
+++ b/src/tasks/copy-folder-task.ts
@@ -1,5 +1,7 @@
 import { FastifyLoggerInstance } from 'fastify';
+
 import { Actor, DatabaseTransactionHandler } from 'graasp';
+
 import FileService from '../fileServices/interface/fileService';
 import { BaseTask } from './base-task';
 

--- a/src/tasks/delete-file-task.test.ts
+++ b/src/tasks/delete-file-task.test.ts
@@ -1,13 +1,16 @@
-import { FastifyLoggerInstance } from 'fastify';
-import fs from 'fs';
 import S3 from 'aws-sdk/clients/s3';
+import fs from 'fs';
+
+import { FastifyLoggerInstance } from 'fastify';
+
 import { DatabaseTransactionHandler } from 'graasp';
+
 import { ServiceMethod } from '..';
 import {
+  DEFAULT_S3_OPTIONS,
+  FILE_SERVICES,
   GRAASP_ACTOR,
   buildDefaultLocalOptions,
-  FILE_SERVICES,
-  DEFAULT_S3_OPTIONS,
 } from '../../test/fixtures';
 import { LocalService } from '../fileServices/localService';
 import { S3Service } from '../fileServices/s3Service';

--- a/src/tasks/delete-file-task.ts
+++ b/src/tasks/delete-file-task.ts
@@ -1,8 +1,10 @@
-import { Item, Actor, DatabaseTransactionHandler } from 'graasp';
 import type { FastifyLoggerInstance } from 'fastify';
-import { BaseTask } from './base-task';
+
+import { Actor, DatabaseTransactionHandler, Item } from 'graasp';
+
 import FileService from '../fileServices/interface/fileService';
 import { DeleteFileInvalidPathError } from '../utils/errors';
+import { BaseTask } from './base-task';
 
 export type DeleteFileInputType = {
   filepath?: string;

--- a/src/tasks/delete-folder-task.test.ts
+++ b/src/tasks/delete-folder-task.test.ts
@@ -1,14 +1,17 @@
-import { FastifyLoggerInstance } from 'fastify';
+import S3 from 'aws-sdk/clients/s3';
 import fs from 'fs';
 import { mkdir } from 'fs/promises';
-import S3 from 'aws-sdk/clients/s3';
+
+import { FastifyLoggerInstance } from 'fastify';
+
 import { DatabaseTransactionHandler } from 'graasp';
+
 import { ServiceMethod } from '..';
 import {
+  DEFAULT_S3_OPTIONS,
+  FILE_SERVICES,
   GRAASP_ACTOR,
   buildDefaultLocalOptions,
-  FILE_SERVICES,
-  DEFAULT_S3_OPTIONS,
 } from '../../test/fixtures';
 import { LocalService } from '../fileServices/localService';
 import { S3Service } from '../fileServices/s3Service';

--- a/src/tasks/delete-folder-task.ts
+++ b/src/tasks/delete-folder-task.ts
@@ -1,7 +1,9 @@
-import { Item, Actor, DatabaseTransactionHandler } from 'graasp';
 import type { FastifyLoggerInstance } from 'fastify';
-import { BaseTask } from './base-task';
+
+import { Actor, DatabaseTransactionHandler, Item } from 'graasp';
+
 import { DeleteFolderInvalidPathError } from '../utils/errors';
+import { BaseTask } from './base-task';
 
 export type DeleteFolderInputType = {
   folderPath?: string;

--- a/src/tasks/download-file-task.test.ts
+++ b/src/tasks/download-file-task.test.ts
@@ -1,16 +1,21 @@
-import { FastifyLoggerInstance, FastifyReply } from 'fastify';
-import fs, { ReadStream } from 'fs';
 import S3 from 'aws-sdk/clients/s3';
+import fs, { ReadStream } from 'fs';
+import { StatusCodes } from 'http-status-codes';
+import path from 'path';
 import { v4 } from 'uuid';
+
+import { FastifyLoggerInstance, FastifyReply } from 'fastify';
+
 import { DatabaseTransactionHandler } from 'graasp';
+
 import { ServiceMethod } from '..';
 import {
-  GRAASP_ACTOR,
-  buildDefaultLocalOptions,
-  FILE_SERVICES,
   DEFAULT_S3_OPTIONS,
+  FILE_SERVICES,
+  GRAASP_ACTOR,
   TEXT_FILE_PATH,
   TEXT_PATH,
+  buildDefaultLocalOptions,
 } from '../../test/fixtures';
 import { LocalService } from '../fileServices/localService';
 import { S3Service } from '../fileServices/s3Service';
@@ -19,9 +24,7 @@ import {
   LocalFileNotFound,
   S3FileNotFound,
 } from '../utils/errors';
-import path from 'path';
 import DownloadFileTask from './download-file-task';
-import { StatusCodes } from 'http-status-codes';
 
 const handler = {} as unknown as DatabaseTransactionHandler;
 const log = {} as unknown as FastifyLoggerInstance;

--- a/src/tasks/download-file-task.ts
+++ b/src/tasks/download-file-task.ts
@@ -1,9 +1,12 @@
-import { Actor, DatabaseTransactionHandler } from 'graasp';
 import { ReadStream } from 'fs';
+
 import type { FastifyLoggerInstance, FastifyReply } from 'fastify';
-import { BaseTask } from './base-task';
+
+import { Actor, DatabaseTransactionHandler } from 'graasp';
+
 import FileService from '../fileServices/interface/fileService';
 import { DownloadFileInvalidParameterError } from '../utils/errors';
+import { BaseTask } from './base-task';
 
 export type DownloadFileInputType = {
   reply?: FastifyReply;

--- a/src/tasks/upload-file-task.test.ts
+++ b/src/tasks/upload-file-task.test.ts
@@ -1,16 +1,19 @@
-import { FastifyLoggerInstance } from 'fastify';
-import fs, { ReadStream } from 'fs';
 import S3 from 'aws-sdk/clients/s3';
-import { DatabaseTransactionHandler } from 'graasp';
+import fs, { ReadStream } from 'fs';
 import path from 'path';
+
+import { FastifyLoggerInstance } from 'fastify';
+
+import { DatabaseTransactionHandler } from 'graasp';
+
 import { ServiceMethod } from '..';
 import {
-  GRAASP_ACTOR,
-  buildDefaultLocalOptions,
-  FILE_SERVICES,
   DEFAULT_S3_OPTIONS,
+  FILE_SERVICES,
+  GRAASP_ACTOR,
   IMAGE_PATH,
   TEXT_FILE_PATH,
+  buildDefaultLocalOptions,
 } from '../../test/fixtures';
 import { LocalService } from '../fileServices/localService';
 import { S3Service } from '../fileServices/s3Service';

--- a/src/tasks/upload-file-task.ts
+++ b/src/tasks/upload-file-task.ts
@@ -1,9 +1,12 @@
-import { Item, Actor, DatabaseTransactionHandler } from 'graasp';
-import type { FastifyLoggerInstance } from 'fastify';
 import { ReadStream } from 'fs';
-import { BaseTask } from './base-task';
+
+import type { FastifyLoggerInstance } from 'fastify';
+
+import { Actor, DatabaseTransactionHandler, Item } from 'graasp';
+
 import FileService from '../fileServices/interface/fileService';
 import { UploadFileInvalidParameterError } from '../utils/errors';
+import { BaseTask } from './base-task';
 
 export type UploadFileInputType = {
   file?: ReadStream;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
-import { Actor, Member, Task, UnknownExtra } from 'graasp';
 import S3 from 'aws-sdk/clients/s3';
 import { ReadStream } from 'fs';
+
+import { Actor, Member, Task, UnknownExtra } from 'graasp';
 
 export enum ServiceMethod {
   S3 = 's3File',

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,6 +1,7 @@
-import { GraaspErrorDetails, GraaspError } from 'graasp';
 import { StatusCodes } from 'http-status-codes';
+
 import { FAILURE_MESSAGES } from '@graasp/translations';
+import { GraaspError, GraaspErrorDetails } from 'graasp';
 
 export class GraaspBaseError implements GraaspError {
   name: string;

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,20 +1,22 @@
 import FormData from 'form-data';
-import fs, { createReadStream, Stats } from 'fs';
-import path from 'path';
+import fs, { Stats, createReadStream } from 'fs';
 import { StatusCodes } from 'http-status-codes';
-import { TaskRunner, Task } from 'graasp-test';
+import path from 'path';
 import { v4 } from 'uuid';
+
+import { Task, TaskRunner } from 'graasp-test';
+
+import { BuildFilePathFunction, ServiceMethod } from '../src/types';
+import { MAX_NB_TASKS_IN_PARALLEL } from '../src/utils/constants';
 import build from './app';
 import {
-  TEXT_FILE_PATH,
   DEFAULT_BUILD_FILE_PATH,
   DEFAULT_S3_OPTIONS,
   FILE_SERVICES,
+  TEXT_FILE_PATH,
   buildDefaultLocalOptions,
 } from './fixtures';
 import { mockCreateDownloadFileTask, mockCreateUploadFileTask } from './mock';
-import { BuildFilePathFunction, ServiceMethod } from '../src/types';
-import { MAX_NB_TASKS_IN_PARALLEL } from '../src/utils/constants';
 
 const runner = new TaskRunner();
 

--- a/test/app.ts
+++ b/test/app.ts
@@ -1,5 +1,7 @@
 import fastify from 'fastify';
+
 import { TaskRunner } from 'graasp-test';
+
 import plugin, { GraaspPluginFileOptions } from '../src/plugin';
 
 const schemas = {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,6 +1,9 @@
-import { Actor, Item, Member, Task } from 'graasp';
 import path from 'path/posix';
+
+import { Actor, Item, Member, Task } from 'graasp';
+
 import { ServiceMethod } from '../src';
+
 export const ROOT_PATH = './test/files';
 export const IMAGE_PATH = './test/files/image.jpeg';
 export const TEXT_PATH = './test/files/1.txt';

--- a/test/mock.ts
+++ b/test/mock.ts
@@ -1,5 +1,6 @@
 import { Item } from 'graasp';
-import { ItemMembershipTaskManager, TaskRunner, Task } from 'graasp-test';
+import { ItemMembershipTaskManager, Task, TaskRunner } from 'graasp-test';
+
 import TaskManager from '../src/task-manager';
 
 export const mockcreateGetOfItemTaskSequence = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,6 +30,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/compat-data@npm:^7.17.10":
+  version: 7.18.5
+  resolution: "@babel/compat-data@npm:7.18.5"
+  checksum: 1baee39fcf0992402ed12d6be43739f3bfb7f0cacddee8959236692ae926bcc3f4fe5abdd907870f4fc8b9fd798c1e6e2999ae97c9b8aedbd834fe03f2765e73
+  languageName: node
+  linkType: hard
+
+"@babel/core@npm:7.13.10":
+  version: 7.13.10
+  resolution: "@babel/core@npm:7.13.10"
+  dependencies:
+    "@babel/code-frame": ^7.12.13
+    "@babel/generator": ^7.13.9
+    "@babel/helper-compilation-targets": ^7.13.10
+    "@babel/helper-module-transforms": ^7.13.0
+    "@babel/helpers": ^7.13.10
+    "@babel/parser": ^7.13.10
+    "@babel/template": ^7.12.13
+    "@babel/traverse": ^7.13.0
+    "@babel/types": ^7.13.0
+    convert-source-map: ^1.7.0
+    debug: ^4.1.0
+    gensync: ^1.0.0-beta.2
+    json5: ^2.1.2
+    lodash: ^4.17.19
+    semver: ^6.3.0
+    source-map: ^0.5.0
+  checksum: 9b3362fd02e6a4f3ad642893312ec3d22713c4eeb2571c994d49c31f38d24893a6a18f4b49abb8d56b510e116278608eaddde2ca72ccb39ab29350efa5af39de
+  languageName: node
+  linkType: hard
+
 "@babel/core@npm:^7.1.0, @babel/core@npm:^7.12.3, @babel/core@npm:^7.7.2, @babel/core@npm:^7.8.0":
   version: 7.17.3
   resolution: "@babel/core@npm:7.17.3"
@@ -53,6 +84,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:7.13.9":
+  version: 7.13.9
+  resolution: "@babel/generator@npm:7.13.9"
+  dependencies:
+    "@babel/types": ^7.13.0
+    jsesc: ^2.5.1
+    source-map: ^0.5.0
+  checksum: 1b0e9fa1b5ea6656f0abeeedc99ff7bffa455d7bf118f4d17a75d80c439206b4ba3e1071c104b486b7447689512969286cbde505e6169ab38cf437e13ca54225
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.13.0, @babel/generator@npm:^7.13.9, @babel/generator@npm:^7.18.2":
+  version: 7.18.2
+  resolution: "@babel/generator@npm:7.18.2"
+  dependencies:
+    "@babel/types": ^7.18.2
+    "@jridgewell/gen-mapping": ^0.3.0
+    jsesc: ^2.5.1
+  checksum: d0661e95532ddd97566d41fec26355a7b28d1cbc4df95fe80cc084c413342935911b48db20910708db39714844ddd614f61c2ec4cca3fb10181418bdcaa2e7a3
+  languageName: node
+  linkType: hard
+
 "@babel/generator@npm:^7.17.3, @babel/generator@npm:^7.7.2":
   version: 7.17.3
   resolution: "@babel/generator@npm:7.17.3"
@@ -61,6 +114,20 @@ __metadata:
     jsesc: ^2.5.1
     source-map: ^0.5.0
   checksum: ddf70e3489976018dfc2da8b9f43ec8c582cac2da681ed4a6227c53b26a9626223e4dca90098b3d3afe43bc67f20160856240e826c56b48e577f34a5a7e22b9f
+  languageName: node
+  linkType: hard
+
+"@babel/helper-compilation-targets@npm:^7.13.10":
+  version: 7.18.2
+  resolution: "@babel/helper-compilation-targets@npm:7.18.2"
+  dependencies:
+    "@babel/compat-data": ^7.17.10
+    "@babel/helper-validator-option": ^7.16.7
+    browserslist: ^4.20.2
+    semver: ^6.3.0
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 4f02e79f20c0b3f8db5049ba8c35027c41ccb3fc7884835d04e49886538e0f55702959db1bb75213c94a5708fec2dc81a443047559a4f184abb884c72c0059b4
   languageName: node
   linkType: hard
 
@@ -84,6 +151,23 @@ __metadata:
   dependencies:
     "@babel/types": ^7.16.7
   checksum: c03a10105d9ebd1fe632a77356b2e6e2f3c44edba9a93b0dc3591b6a66bd7a2e323dd9502f9ce96fc6401234abff1907aa877b6674f7826b61c953f7c8204bbe
+  languageName: node
+  linkType: hard
+
+"@babel/helper-environment-visitor@npm:^7.18.2":
+  version: 7.18.2
+  resolution: "@babel/helper-environment-visitor@npm:7.18.2"
+  checksum: 1a9c8726fad454a082d077952a90f17188e92eabb3de236cb4782c49b39e3f69c327e272b965e9a20ff8abf37d30d03ffa6fd7974625a6c23946f70f7527f5e9
+  languageName: node
+  linkType: hard
+
+"@babel/helper-function-name@npm:^7.12.13, @babel/helper-function-name@npm:^7.17.9":
+  version: 7.17.9
+  resolution: "@babel/helper-function-name@npm:7.17.9"
+  dependencies:
+    "@babel/template": ^7.16.7
+    "@babel/types": ^7.17.0
+  checksum: a59b2e5af56d8f43b9b0019939a43774754beb7cb01a211809ca8031c71890999d07739e955343135ec566c4d8ff725435f1f60fb0af3bb546837c1f9f84f496
   languageName: node
   linkType: hard
 
@@ -125,6 +209,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-module-transforms@npm:^7.13.0":
+  version: 7.18.0
+  resolution: "@babel/helper-module-transforms@npm:7.18.0"
+  dependencies:
+    "@babel/helper-environment-visitor": ^7.16.7
+    "@babel/helper-module-imports": ^7.16.7
+    "@babel/helper-simple-access": ^7.17.7
+    "@babel/helper-split-export-declaration": ^7.16.7
+    "@babel/helper-validator-identifier": ^7.16.7
+    "@babel/template": ^7.16.7
+    "@babel/traverse": ^7.18.0
+    "@babel/types": ^7.18.0
+  checksum: 824c3967c08d75bb36adc18c31dcafebcd495b75b723e2e17c6185e88daf5c6db62a6a75d9f791b5f38618a349e7cb32503e715a1b9a4e8bad4d0f43e3e6b523
+  languageName: node
+  linkType: hard
+
 "@babel/helper-module-transforms@npm:^7.16.7":
   version: 7.16.7
   resolution: "@babel/helper-module-transforms@npm:7.16.7"
@@ -157,7 +257,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-split-export-declaration@npm:^7.16.7":
+"@babel/helper-simple-access@npm:^7.17.7":
+  version: 7.18.2
+  resolution: "@babel/helper-simple-access@npm:7.18.2"
+  dependencies:
+    "@babel/types": ^7.18.2
+  checksum: c0862b56db7e120754d89273a039b128c27517389f6a4425ff24e49779791e8fe10061579171fb986be81fa076778acb847c709f6f5e396278d9c5e01360c375
+  languageName: node
+  linkType: hard
+
+"@babel/helper-split-export-declaration@npm:^7.12.13, @babel/helper-split-export-declaration@npm:^7.16.7":
   version: 7.16.7
   resolution: "@babel/helper-split-export-declaration@npm:7.16.7"
   dependencies:
@@ -166,7 +275,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^7.16.7":
+"@babel/helper-validator-identifier@npm:^7.12.11, @babel/helper-validator-identifier@npm:^7.16.7":
   version: 7.16.7
   resolution: "@babel/helper-validator-identifier@npm:7.16.7"
   checksum: dbb3db9d184343152520a209b5684f5e0ed416109cde82b428ca9c759c29b10c7450657785a8b5c5256aa74acc6da491c1f0cf6b784939f7931ef82982051b69
@@ -177,6 +286,17 @@ __metadata:
   version: 7.16.7
   resolution: "@babel/helper-validator-option@npm:7.16.7"
   checksum: c5ccc451911883cc9f12125d47be69434f28094475c1b9d2ada7c3452e6ac98a1ee8ddd364ca9e3f9855fcdee96cdeafa32543ebd9d17fee7a1062c202e80570
+  languageName: node
+  linkType: hard
+
+"@babel/helpers@npm:^7.13.10":
+  version: 7.18.2
+  resolution: "@babel/helpers@npm:7.18.2"
+  dependencies:
+    "@babel/template": ^7.16.7
+    "@babel/traverse": ^7.18.2
+    "@babel/types": ^7.18.2
+  checksum: 94620242f23f6d5f9b83a02b1aa1632ffb05b0815e1bb53d3b46d64aa8e771066bba1db8bd267d9091fb00134cfaeda6a8d69d1d4cc2c89658631adfa077ae70
   languageName: node
   linkType: hard
 
@@ -202,12 +322,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/parser@npm:7.14.6":
+  version: 7.14.6
+  resolution: "@babel/parser@npm:7.14.6"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 104482e07971a78a3d68a0c329b1303981a272f55a510d39c93dac3c293f207ec863329046abc5d8bb86db58c49670cc607654793470a87ccd386544c2ccf298
+  languageName: node
+  linkType: hard
+
 "@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.16.7, @babel/parser@npm:^7.17.3":
   version: 7.17.3
   resolution: "@babel/parser@npm:7.17.3"
   bin:
     parser: ./bin/babel-parser.js
   checksum: 311869baef97c7630ac3b3c4600da18229b95aa2785b2daab2044384745fe0653070916ade28749fb003f7369a081111ada53e37284ba48d6b5858cbb9e411d1
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.13.0, @babel/parser@npm:^7.13.10, @babel/parser@npm:^7.18.5":
+  version: 7.18.5
+  resolution: "@babel/parser@npm:7.18.5"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 4976349d8681af215fd5771bd5b74568cc95a2e8bf2afcf354bf46f73f3d6f08d54705f354b1d0012f914dd02a524b7d37c5c1204ccaafccb9db3c37dba96a9b
   languageName: node
   linkType: hard
 
@@ -363,7 +501,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.16.7, @babel/template@npm:^7.3.3":
+"@babel/template@npm:^7.12.13, @babel/template@npm:^7.16.7, @babel/template@npm:^7.3.3":
   version: 7.16.7
   resolution: "@babel/template@npm:7.16.7"
   dependencies:
@@ -371,6 +509,41 @@ __metadata:
     "@babel/parser": ^7.16.7
     "@babel/types": ^7.16.7
   checksum: 10cd112e89276e00f8b11b55a51c8b2f1262c318283a980f4d6cdb0286dc05734b9aaeeb9f3ad3311900b09bc913e02343fcaa9d4a4f413964aaab04eb84ac4a
+  languageName: node
+  linkType: hard
+
+"@babel/traverse@npm:7.13.0":
+  version: 7.13.0
+  resolution: "@babel/traverse@npm:7.13.0"
+  dependencies:
+    "@babel/code-frame": ^7.12.13
+    "@babel/generator": ^7.13.0
+    "@babel/helper-function-name": ^7.12.13
+    "@babel/helper-split-export-declaration": ^7.12.13
+    "@babel/parser": ^7.13.0
+    "@babel/types": ^7.13.0
+    debug: ^4.1.0
+    globals: ^11.1.0
+    lodash: ^4.17.19
+  checksum: 7d584b5541396b02f6973ba8ec8a067f2a6c2fd2e894c663dfae36e86e65a004a6865fbffbfc89ca040c894f9c12134bb971d31f09e7ec32c28e9b18bf737f2a
+  languageName: node
+  linkType: hard
+
+"@babel/traverse@npm:^7.13.0, @babel/traverse@npm:^7.18.0, @babel/traverse@npm:^7.18.2":
+  version: 7.18.5
+  resolution: "@babel/traverse@npm:7.18.5"
+  dependencies:
+    "@babel/code-frame": ^7.16.7
+    "@babel/generator": ^7.18.2
+    "@babel/helper-environment-visitor": ^7.18.2
+    "@babel/helper-function-name": ^7.17.9
+    "@babel/helper-hoist-variables": ^7.16.7
+    "@babel/helper-split-export-declaration": ^7.16.7
+    "@babel/parser": ^7.18.5
+    "@babel/types": ^7.18.4
+    debug: ^4.1.0
+    globals: ^11.1.0
+  checksum: cc0470c880e15a748ca3424665c65836dba450fd0331fb28f9d30aa42acd06387b6321996517ab1761213f781fe8d657e2c3ad67c34afcb766d50653b393810f
   languageName: node
   linkType: hard
 
@@ -392,6 +565,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/types@npm:7.13.0":
+  version: 7.13.0
+  resolution: "@babel/types@npm:7.13.0"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.12.11
+    lodash: ^4.17.19
+    to-fast-properties: ^2.0.0
+  checksum: 3dbb08add345325a49e1deebefa8d3774a8ab055c4be675c339a389358f4b3443652ded4bfdb230b342c6af12593a6fd3fb95156564e7ec84081018815896821
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.16.7, @babel/types@npm:^7.17.0, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.8.3":
   version: 7.17.0
   resolution: "@babel/types@npm:7.17.0"
@@ -399,6 +583,16 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.16.7
     to-fast-properties: ^2.0.0
   checksum: 12e5a287986fe557188e87b2c5202223f1dc83d9239a196ab936fdb9f8c1eb0be717ff19f934b5fad4e29a75586d5798f74bed209bccea1c20376b9952056f0e
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.13.0, @babel/types@npm:^7.18.0, @babel/types@npm:^7.18.2, @babel/types@npm:^7.18.4":
+  version: 7.18.4
+  resolution: "@babel/types@npm:7.18.4"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.16.7
+    to-fast-properties: ^2.0.0
+  checksum: 85df59beb99c1b95e9e41590442f2ffa1e5b1b558d025489db40c9f7c906bd03a17da26c3ec486e5800e80af27c42ca7eee9506d9212ab17766d2d68d30fbf52
   languageName: node
   linkType: hard
 
@@ -926,10 +1120,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/gen-mapping@npm:^0.3.0":
+  version: 0.3.1
+  resolution: "@jridgewell/gen-mapping@npm:0.3.1"
+  dependencies:
+    "@jridgewell/set-array": ^1.0.0
+    "@jridgewell/sourcemap-codec": ^1.4.10
+    "@jridgewell/trace-mapping": ^0.3.9
+  checksum: e9e7bb3335dea9e60872089761d4e8e089597360cdb1af90370e9d53b7d67232c1e0a3ab65fbfef4fc785745193fbc56bff9f3a6cab6c6ce3f15e12b4191f86b
+  languageName: node
+  linkType: hard
+
 "@jridgewell/resolve-uri@npm:^3.0.3":
   version: 3.0.5
   resolution: "@jridgewell/resolve-uri@npm:3.0.5"
   checksum: 1ee652b693da7979ac4007926cc3f0a32b657ffeb913e111f44e5b67153d94a2f28a1d560101cc0cf8087625468293a69a00f634a2914e1a6d0817ba2039a913
+  languageName: node
+  linkType: hard
+
+"@jridgewell/set-array@npm:^1.0.0":
+  version: 1.1.1
+  resolution: "@jridgewell/set-array@npm:1.1.1"
+  checksum: cc5d91e0381c347e3edee4ca90b3c292df9e6e55f29acbe0dd97de8651b4730e9ab761406fd572effa79972a0edc55647b627f8c72315e276d959508853d9bf2
   languageName: node
   linkType: hard
 
@@ -947,6 +1159,16 @@ __metadata:
     "@jridgewell/resolve-uri": ^3.0.3
     "@jridgewell/sourcemap-codec": ^1.4.10
   checksum: ab8bce84bbbc8c34f3ba8325ed926f8f2d3098983c10442a80c55764c4eb6e47d5b92d8ff20a0dd868c3e76a3535651fd8a0138182c290dbfc8396195685c37b
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:^0.3.9":
+  version: 0.3.13
+  resolution: "@jridgewell/trace-mapping@npm:0.3.13"
+  dependencies:
+    "@jridgewell/resolve-uri": ^3.0.3
+    "@jridgewell/sourcemap-codec": ^1.4.10
+  checksum: e38254e830472248ca10a6ed1ae75af5e8514f0680245a5e7b53bc3c030fd8691d4d3115d80595b45d3badead68269769ed47ecbbdd67db1343a11f05700e75a
   languageName: node
   linkType: hard
 
@@ -1019,6 +1241,23 @@ __metadata:
   version: 1.1.2
   resolution: "@tootallnate/once@npm:1.1.2"
   checksum: e1fb1bbbc12089a0cb9433dc290f97bddd062deadb6178ce9bcb93bb7c1aecde5e60184bc7065aec42fe1663622a213493c48bbd4972d931aae48315f18e1be9
+  languageName: node
+  linkType: hard
+
+"@trivago/prettier-plugin-sort-imports@npm:3.2.0":
+  version: 3.2.0
+  resolution: "@trivago/prettier-plugin-sort-imports@npm:3.2.0"
+  dependencies:
+    "@babel/core": 7.13.10
+    "@babel/generator": 7.13.9
+    "@babel/parser": 7.14.6
+    "@babel/traverse": 7.13.0
+    "@babel/types": 7.13.0
+    javascript-natural-sort: 0.7.1
+    lodash: 4.17.21
+  peerDependencies:
+    prettier: 2.x
+  checksum: 22461433fa0dc82621713cdfb88f8f527c6c41729e9859bb7f0106ef23c35b0da591ee7fed63516be7e8df5604dc8055f0c7e200fed1ef97f44000c9fe25a890
   languageName: node
   linkType: hard
 
@@ -1779,6 +2018,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"browserslist@npm:^4.20.2":
+  version: 4.21.0
+  resolution: "browserslist@npm:4.21.0"
+  dependencies:
+    caniuse-lite: ^1.0.30001358
+    electron-to-chromium: ^1.4.164
+    node-releases: ^2.0.5
+    update-browserslist-db: ^1.0.0
+  bin:
+    browserslist: cli.js
+  checksum: dfad21090d0a4745f55c4c126172bc4d5743a500440791c731773f215a16f201a0b8a114c040fa5788ce2d1a13076601f751e54ee6c5f9de59f0cee3ce9875e3
+  languageName: node
+  linkType: hard
+
 "bs-logger@npm:0.x":
   version: 0.2.6
   resolution: "bs-logger@npm:0.2.6"
@@ -1877,6 +2130,13 @@ __metadata:
   version: 1.0.30001312
   resolution: "caniuse-lite@npm:1.0.30001312"
   checksum: 753fb9ea1e02e999430b323a71b5acab5120f3b5fc0161b01669f54a3ef5c5296240b6ae9b79b12a3742e3aed216aa9ee3d5398a23c16d08625ccd376b79545d
+  languageName: node
+  linkType: hard
+
+"caniuse-lite@npm:^1.0.30001358":
+  version: 1.0.30001358
+  resolution: "caniuse-lite@npm:1.0.30001358"
+  checksum: dd8d8e6b1f5e24b97d38bb110c35b96f701f8a303e7066e9d0dc4d0ae99d741e89d56688d4e811e260c5fe573835f2bedd49a6f35f3f43e9fa7e5d154b1fad0e
   languageName: node
   linkType: hard
 
@@ -2315,6 +2575,13 @@ __metadata:
   dependencies:
     is-obj: ^2.0.0
   checksum: d5775790093c234ef4bfd5fbe40884ff7e6c87573e5339432870616331189f7f5d86575c5b5af2dcf0f61172990f4f734d07844b1f23482fff09e3c4bead05ea
+  languageName: node
+  linkType: hard
+
+"electron-to-chromium@npm:^1.4.164":
+  version: 1.4.165
+  resolution: "electron-to-chromium@npm:1.4.165"
+  checksum: dbbb2e825df41cd012401e36b3c0ff934607c5ddee59402763b19093ead6ca20a87656474189de01dafb088e8e73792685bd01f50a62e9b86687d717179dca65
   languageName: node
   linkType: hard
 
@@ -3062,6 +3329,7 @@ __metadata:
     "@commitlint/config-conventional": 16.2.1
     "@fastify/multipart": 6.0.0
     "@graasp/translations": "github:graasp/graasp-translations"
+    "@trivago/prettier-plugin-sort-imports": 3.2.0
     "@types/content-disposition": 0.5.4
     "@types/fs-extra": 9.0.13
     "@types/graasp": "github:graasp/graasp-types"
@@ -3534,6 +3802,13 @@ __metadata:
     html-escaper: ^2.0.0
     istanbul-lib-report: ^3.0.0
   checksum: 2132983355710c522f6b26808015cab9a0ee8b9f5ae0db0d3edeff40b886dd83cb670fb123cb7b32dbe59473d7c00cdde2ba6136bc0acdb20a865fccea64dfe1
+  languageName: node
+  linkType: hard
+
+"javascript-natural-sort@npm:0.7.1":
+  version: 0.7.1
+  resolution: "javascript-natural-sort@npm:0.7.1"
+  checksum: 161e2c512cc7884bc055a582c6645d9032cab88497a76123d73cb23bfb03d97a04cf7772ecdb8bd3366fc07192c2f996366f479f725c23ef073fffe03d6a586a
   languageName: node
   linkType: hard
 
@@ -4263,7 +4538,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.7.0":
+"lodash@npm:4.17.21, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.7.0":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
@@ -4594,6 +4869,13 @@ __metadata:
   version: 2.0.2
   resolution: "node-releases@npm:2.0.2"
   checksum: da858bf86b4d512842379749f5a5e4196ddab05ba18ffcf29f05bf460beceaca927f070f4430bb5046efec18941ddbc85e4c5fdbb83afc28a38dd6069a2f255e
+  languageName: node
+  linkType: hard
+
+"node-releases@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "node-releases@npm:2.0.5"
+  checksum: e85d949addd19f8827f32569d2be5751e7812ccf6cc47879d49f79b5234ff4982225e39a3929315f96370823b070640fb04d79fc0ddec8b515a969a03493a42f
   languageName: node
   linkType: hard
 
@@ -6033,6 +6315,20 @@ __metadata:
   version: 2.0.0
   resolution: "universalify@npm:2.0.0"
   checksum: 2406a4edf4a8830aa6813278bab1f953a8e40f2f63a37873ffa9a3bc8f9745d06cc8e88f3572cb899b7e509013f7f6fcc3e37e8a6d914167a5381d8440518c44
+  languageName: node
+  linkType: hard
+
+"update-browserslist-db@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "update-browserslist-db@npm:1.0.3"
+  dependencies:
+    escalade: ^3.1.1
+    picocolors: ^1.0.0
+  peerDependencies:
+    browserslist: ">= 4.21.0"
+  bin:
+    browserslist-lint: cli.js
+  checksum: 7ffbb87405efddd34d69f7d5929b44a3c4c7d72751542eb9e494536cafb0d57290d261af25986584dabc5b76ddd719061b5efb4ddf26af092bf35b095f20ce90
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR:
- applies the `COPY` metadata directive in S3 when copying folders
- refactors the imports in all source files using `@trivago/prettier-plugin-sort-imports`